### PR TITLE
Fix `verificationVia` enum order.

### DIFF
--- a/src/enums/verification-via-enum.js
+++ b/src/enums/verification-via-enum.js
@@ -4,6 +4,6 @@
  */
 
 export default {
-  CALL: 'sms',
-  SMS: 'call'
+  CALL: 'call',
+  SMS: 'sms'
 };


### PR DESCRIPTION
The enums for `call` and `sms` were backwards.