### PR TITLE
Change Phone Verification token type from Number to String.

### DIFF
--- a/dist/src/asserts/index.js
+++ b/dist/src/asserts/index.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.VerificationVia = exports.TotpToken = exports.Signature = exports.Phone = exports.Logo = exports.Locale = exports.CountryOrCallingCode = exports.AuthyId = exports.Activity = undefined;
+exports.VerificationVia = exports.TotpToken = exports.Signature = exports.PhoneToken = exports.Phone = exports.Logo = exports.Locale = exports.CountryOrCallingCode = exports.AuthyId = exports.Activity = undefined;
 
 var _activityAssert = require('./activity-assert');
 
@@ -29,6 +29,10 @@ var _phoneAssert = require('./phone-assert');
 
 var _phoneAssert2 = _interopRequireDefault(_phoneAssert);
 
+var _phoneTokenAssert = require('./phone-token-assert');
+
+var _phoneTokenAssert2 = _interopRequireDefault(_phoneTokenAssert);
+
 var _signatureAssert = require('./signature-assert');
 
 var _signatureAssert2 = _interopRequireDefault(_signatureAssert);
@@ -47,15 +51,17 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  * Export named asserts.
  */
 
+/**
+ * Module dependencies.
+ */
+
 exports.Activity = _activityAssert2.default;
 exports.AuthyId = _authyIdAssert2.default;
 exports.CountryOrCallingCode = _countryOrCallingCodeAssert2.default;
 exports.Locale = _localeAssert2.default;
 exports.Logo = _logoAssert2.default;
 exports.Phone = _phoneAssert2.default;
+exports.PhoneToken = _phoneTokenAssert2.default;
 exports.Signature = _signatureAssert2.default;
 exports.TotpToken = _totpTokenAssert2.default;
 exports.VerificationVia = _verificationViaAssert2.default;
-/**
- * Module dependencies.
- */

--- a/dist/src/asserts/phone-token-assert.js
+++ b/dist/src/asserts/phone-token-assert.js
@@ -1,0 +1,61 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = phoneTokenAssert;
+
+var _lodash = require('lodash');
+
+var _validator = require('validator.js');
+
+/**
+ * Instances.
+ */
+
+/**
+ * Module dependencies.
+ */
+
+const numeric = /^\d+$/;
+
+/**
+ * Export `PhoneTokenAssert`.
+ *
+ * Validate an Authy Phone Validation token.
+ * As far as I know there is no defined specification for this, but in my limited testing this only ever returns a four digit number.
+ * Because of this we will be somewhat lenient and allow any number between 4 and 8 digits.
+ */
+
+function phoneTokenAssert() {
+  // Class name.
+  this.__class__ = 'PhoneToken';
+
+  // Token boundaries.
+  this.boundaries = {
+    max: 8,
+    min: 4
+  };
+
+  // Validation algorithm.
+  this.validate = value => {
+    // Because these codes might start with a zero we must represent them as Strings.
+    if (!(0, _lodash.isString)(value)) {
+      throw new _validator.Violation(this, value, { value: 'must_be_a_string' });
+    }
+
+    if (!numeric.test(value)) {
+      throw new _validator.Violation(this, value, { value: 'must_be_numeric' });
+    }
+
+    try {
+      _validator.Assert.ofLength(this.boundaries).validate(value);
+    } catch (e) {
+      throw new _validator.Violation(this, value, e.violation);
+    }
+
+    return true;
+  };
+
+  return this;
+}

--- a/dist/src/client.js
+++ b/dist/src/client.js
@@ -864,7 +864,7 @@ class Client {
       (0, _validator.validate)({ countryCode: countryOrCallingCode, phone: phone, token: token }, {
         countryCode: [_validator.Assert.required(), _validator.Assert.countryOrCallingCode()],
         phone: [_validator.Assert.required(), _validator.Assert.phone(countryOrCallingCode)],
-        token: [_validator.Assert.required(), _validator.Assert.integer()]
+        token: [_validator.Assert.required(), _validator.Assert.phoneToken()]
       });
 
       const parsed = (0, _phoneParser2.default)({ countryOrCallingCode: countryOrCallingCode, phone: phone });

--- a/dist/test/asserts/phone-token-assert_test.js
+++ b/dist/test/asserts/phone-token-assert_test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+var _phoneTokenAssert = require('../../src/asserts/phone-token-assert');
+
+var _phoneTokenAssert2 = _interopRequireDefault(_phoneTokenAssert);
+
+var _should = require('should');
+
+var _should2 = _interopRequireDefault(_should);
+
+var _validator = require('validator.js');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+/**
+ * Extend Assert with `PhoneToken`.
+ */
+
+const Assert = _validator.Assert.extend({ PhoneToken: _phoneTokenAssert2.default });
+
+/**
+ * Test `PhoneTokenAssert`.
+ */
+
+/**
+ * Module dependencies.
+ */
+
+describe('PhoneTokenAssert', () => {
+  it('should throw an error if the token is not a string', () => {
+    [[], {}, 2].forEach(choice => {
+      try {
+        new Assert().PhoneToken().validate(choice);
+
+        _should2.default.fail();
+      } catch (e) {
+        e.should.be.instanceOf(_validator.Violation);
+        e.violation.value.should.equal('must_be_a_string');
+      }
+    });
+  });
+
+  it('should throw an error if the token is not numeric', () => {
+    ['-10', '1.101', '1e6', new Array(50).join('foo')].forEach(value => {
+      try {
+        new Assert().PhoneToken().validate(value);
+
+        _should2.default.fail();
+      } catch (e) {
+        e.should.be.instanceOf(_validator.Violation);
+        e.violation.value.should.equal('must_be_numeric');
+      }
+    });
+  });
+
+  it('should throw an error if the token length is below the minimum boundary', () => {
+    try {
+      new Assert().PhoneToken().validate('10');
+
+      _should2.default.fail();
+    } catch (e) {
+      e.should.be.instanceOf(_validator.Violation);
+      e.violation.min.should.equal(4);
+    }
+  });
+
+  it('should throw an error if the token length is above the maximum boundary', () => {
+    ['1001001001', '000000009', '0000000010'].forEach(value => {
+      try {
+        new Assert().PhoneToken().validate(value);
+
+        _should2.default.fail();
+      } catch (e) {
+        e.should.be.instanceOf(_validator.Violation);
+        e.violation.max.should.equal(8);
+      }
+    });
+  });
+
+  it('should have default boundaries between 4 and 8 digits', () => {
+    const assert = new Assert().PhoneToken();
+
+    assert.boundaries.min.should.equal(4);
+    assert.boundaries.max.should.equal(8);
+  });
+
+  it('should accept tokens between 4 and 8 digits', () => {
+    ['1234', '0601338', '5166240', '12345678'].forEach(value => {
+      new Assert().PhoneToken().validate(value);
+    });
+  });
+});

--- a/dist/test/client_test.js
+++ b/dist/test/client_test.js
@@ -661,12 +661,12 @@ describe('Client', () => {
 
     it('should throw an error if `token` is invalid', _asyncToGenerator(function* () {
       try {
-        yield client.verifyPhone({ token: 'foobar' });
+        yield client.verifyPhone({ token: 1234 });
 
         _should2.default.fail();
       } catch (e) {
         e.should.be.instanceOf(_errors.ValidationFailedError);
-        e.errors.token[0].show().assert.should.equal('Integer');
+        e.errors.token[0].show().assert.should.equal('PhoneToken');
       }
     }));
 
@@ -674,7 +674,7 @@ describe('Client', () => {
       (0, _nock2.default)(/authy/).get(/\//).reply(200, { success: true });
 
       try {
-        yield client.verifyPhone({ countryCode: 'US', phone: '7754615609', token: 1234 });
+        yield client.verifyPhone({ countryCode: 'US', phone: '7754615609', token: '1234' });
 
         _should2.default.fail();
       } catch (e) {
@@ -688,7 +688,7 @@ describe('Client', () => {
       (0, _nock2.default)(/authy/).get(/\//).reply(200, { carrier: 123, is_cellphone: 'true', is_ported: 'true', message: 123, success: true });
 
       try {
-        yield client.verifyPhone({ countryCode: 'US', phone: '7754615609', token: 1234 });
+        yield client.verifyPhone({ countryCode: 'US', phone: '7754615609', token: '1234' });
 
         _should2.default.fail();
       } catch (e) {
@@ -710,7 +710,7 @@ describe('Client', () => {
         }
       });
 
-      const phoneVerification = yield client.verifyPhone({ countryCode: 'US', phone: '7754615609', token: 1234 });
+      const phoneVerification = yield client.verifyPhone({ countryCode: 'US', phone: '7754615609', token: '1234' });
 
       phoneVerification.should.have.keys('message', 'success');
     }));
@@ -718,7 +718,7 @@ describe('Client', () => {
     it('should accept a callback', done => {
       mocks.verifyPhone.succeed();
 
-      client.verifyPhone({ countryCode: 'US', phone: '7754615609', token: 1234 }, (err, response) => {
+      client.verifyPhone({ countryCode: 'US', phone: '7754615609', token: '1234' }, (err, response) => {
         _should2.default.not.exist(err);
         response.should.be.an.Object();
 

--- a/src/asserts/index.js
+++ b/src/asserts/index.js
@@ -9,6 +9,7 @@ import CountryOrCallingCode from './country-or-calling-code-assert';
 import Locale from './locale-assert';
 import Logo from './logo-assert';
 import Phone from './phone-assert';
+import PhoneToken from './phone-token-assert';
 import Signature from './signature-assert';
 import TotpToken from './totp-token-assert';
 import VerificationVia from './verification-via-assert';
@@ -24,6 +25,7 @@ export {
   Locale,
   Logo,
   Phone,
+  PhoneToken,
   Signature,
   TotpToken,
   VerificationVia

--- a/src/asserts/phone-token-assert.js
+++ b/src/asserts/phone-token-assert.js
@@ -1,0 +1,54 @@
+
+/**
+ * Module dependencies.
+ */
+
+import { isString } from 'lodash';
+import { Violation, Assert as is } from 'validator.js';
+
+/**
+ * Instances.
+ */
+
+const numeric = /^\d+$/;
+
+/**
+ * Export `PhoneTokenAssert`.
+ *
+ * Validate an Authy Phone Validation token.
+ * As far as I know there is no defined specification for this, but in my limited testing this only ever returns a four digit number.
+ * Because of this we will be somewhat lenient and allow any number between 4 and 8 digits.
+ */
+
+export default function phoneTokenAssert() {
+  // Class name.
+  this.__class__ = 'PhoneToken';
+
+  // Token boundaries.
+  this.boundaries = {
+    max: 8,
+    min: 4
+  };
+
+  // Validation algorithm.
+  this.validate = value => {
+    // Because these codes might start with a zero we must represent them as Strings.
+    if (!isString(value)) {
+      throw new Violation(this, value, { value: 'must_be_a_string' });
+    }
+
+    if (!numeric.test(value)) {
+      throw new Violation(this, value, { value: 'must_be_numeric' });
+    }
+
+    try {
+      is.ofLength(this.boundaries).validate(value);
+    } catch (e) {
+      throw new Violation(this, value, e.violation);
+    }
+
+    return true;
+  };
+
+  return this;
+}

--- a/src/client.js
+++ b/src/client.js
@@ -616,7 +616,7 @@ export default class Client {
       validate({ countryCode: countryOrCallingCode, phone, token }, {
         countryCode: [is.required(), is.countryOrCallingCode()],
         phone: [is.required(), is.phone(countryOrCallingCode)],
-        token: [is.required(), is.string()]
+        token: [is.required(), is.phoneToken()]
       });
 
       const parsed = parsePhone({ countryOrCallingCode, phone });

--- a/src/client.js
+++ b/src/client.js
@@ -616,7 +616,7 @@ export default class Client {
       validate({ countryCode: countryOrCallingCode, phone, token }, {
         countryCode: [is.required(), is.countryOrCallingCode()],
         phone: [is.required(), is.phone(countryOrCallingCode)],
-        token: [is.required(), is.integer()]
+        token: [is.required(), is.string()]
       });
 
       const parsed = parsePhone({ countryOrCallingCode, phone });

--- a/test/asserts/phone-token-assert_test.js
+++ b/test/asserts/phone-token-assert_test.js
@@ -1,0 +1,83 @@
+
+/**
+ * Module dependencies.
+ */
+
+import PhoneToken from '../../src/asserts/phone-token-assert';
+import should from 'should';
+import { Assert as BaseAssert, Violation } from 'validator.js';
+
+/**
+ * Extend Assert with `PhoneToken`.
+ */
+
+const Assert = BaseAssert.extend({ PhoneToken });
+
+/**
+ * Test `PhoneTokenAssert`.
+ */
+
+describe('PhoneTokenAssert', () => {
+  it('should throw an error if the token is not a string', () => {
+    [[], {}, 2].forEach(choice => {
+      try {
+        new Assert().PhoneToken().validate(choice);
+
+        should.fail();
+      } catch (e) {
+        e.should.be.instanceOf(Violation);
+        e.violation.value.should.equal('must_be_a_string');
+      }
+    });
+  });
+
+  it('should throw an error if the token is not numeric', () => {
+    ['-10', '1.101', '1e6', new Array(50).join('foo')].forEach(value => {
+      try {
+        new Assert().PhoneToken().validate(value);
+
+        should.fail();
+      } catch (e) {
+        e.should.be.instanceOf(Violation);
+        e.violation.value.should.equal('must_be_numeric');
+      }
+    });
+  });
+
+  it('should throw an error if the token length is below the minimum boundary', () => {
+    try {
+      new Assert().PhoneToken().validate('10');
+
+      should.fail();
+    } catch (e) {
+      e.should.be.instanceOf(Violation);
+      e.violation.min.should.equal(4);
+    }
+  });
+
+  it('should throw an error if the token length is above the maximum boundary', () => {
+    ['1001001001', '000000009', '0000000010'].forEach(value => {
+      try {
+        new Assert().PhoneToken().validate(value);
+
+        should.fail();
+      } catch (e) {
+        e.should.be.instanceOf(Violation);
+        e.violation.max.should.equal(8);
+      }
+    });
+  });
+
+  it('should have default boundaries between 4 and 8 digits', () => {
+    const assert = new Assert().PhoneToken();
+
+    assert.boundaries.min.should.equal(4);
+    assert.boundaries.max.should.equal(8);
+  });
+
+  it('should accept tokens between 4 and 8 digits', () => {
+    ['1234', '0601338', '5166240', '12345678'].forEach(value => {
+      new Assert().PhoneToken().validate(value);
+    });
+  });
+});

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -642,12 +642,12 @@ describe('Client', () => {
 
     it('should throw an error if `token` is invalid', async () => {
       try {
-        await client.verifyPhone({ token: 'foobar' });
+        await client.verifyPhone({ token: 1234 });
 
         should.fail();
       } catch (e) {
         e.should.be.instanceOf(ValidationFailedError);
-        e.errors.token[0].show().assert.should.equal('Integer');
+        e.errors.token[0].show().assert.should.equal('PhoneToken');
       }
     });
 
@@ -655,7 +655,7 @@ describe('Client', () => {
       nock(/authy/).get(/\//).reply(200, { success: true });
 
       try {
-        await client.verifyPhone({ countryCode: 'US', phone: '7754615609', token: 1234 });
+        await client.verifyPhone({ countryCode: 'US', phone: '7754615609', token: '1234' });
 
         should.fail();
       } catch (e) {
@@ -669,7 +669,7 @@ describe('Client', () => {
       nock(/authy/).get(/\//).reply(200, { carrier: 123, is_cellphone: 'true', is_ported: 'true', message: 123, success: true });
 
       try {
-        await client.verifyPhone({ countryCode: 'US', phone: '7754615609', token: 1234 });
+        await client.verifyPhone({ countryCode: 'US', phone: '7754615609', token: '1234' });
 
         should.fail();
       } catch (e) {
@@ -691,7 +691,7 @@ describe('Client', () => {
         }
       });
 
-      const phoneVerification = await client.verifyPhone({ countryCode: 'US', phone: '7754615609', token: 1234 });
+      const phoneVerification = await client.verifyPhone({ countryCode: 'US', phone: '7754615609', token: '1234' });
 
       phoneVerification.should.have.keys('message', 'success');
     });
@@ -699,7 +699,7 @@ describe('Client', () => {
     it('should accept a callback', done => {
       mocks.verifyPhone.succeed();
 
-      client.verifyPhone({ countryCode: 'US', phone: '7754615609', token: 1234 }, (err, response) => {
+      client.verifyPhone({ countryCode: 'US', phone: '7754615609', token: '1234' }, (err, response) => {
         should.not.exist(err);
         response.should.be.an.Object();
 


### PR DESCRIPTION
This fixes a bug where a phone verification code starting with a zero is unverifiable. This change will break any existing implementations using this method, however any system without this will be unusable 1/10 times, requiring the user to wait for their current token to expire.

Edit: ~~It looks like this needs some more work. Right now Authy gives me the following response when attempting a code.~~

Edit: The issue was missing tests. I've added them now.