### PR TITLE
Encode space as + in signature assertion

### DIFF
--- a/src/asserts/signature-assert.js
+++ b/src/asserts/signature-assert.js
@@ -35,7 +35,10 @@ export default function signatureAssert({ key, request } = {}) {
 
     const { body, headers: { 'x-authy-signature-nonce': nonce, host }, method, protocol, url: path } = this.request;
     const url = parse(`${protocol}://${host}${path}`, true);
-    const encoded = qs.stringify(body, { sort: (a, b) => a.localeCompare(b) });
+    let encoded = qs.stringify(body, { sort: (a, b) => a.localeCompare(b) });
+
+    // "qs" encodes space as %20, but Authy encodes as + in their signature generation
+    encoded = encoded.replace(/%20/g, '+');
     const data = `${nonce}|${method}|${url.protocol}//${url.host}${url.pathname}|${encoded}`;
     const signature = createHmac('sha256', this.key).update(data).digest('base64');
 

--- a/test/asserts/signature-assert_test.js
+++ b/test/asserts/signature-assert_test.js
@@ -99,4 +99,28 @@ describe('SignatureAssert', () => {
       }
     }).validate('uq/wB8AR1Acvn0wFcjm7mmBJyR11nuuMhMy6semsAO8=');
   });
+
+  it('should encode spaces as + instead of %20', () => {
+    new Assert().Signature({
+      key: 'foo',
+      request: {
+        body: {
+          qux: 'net',
+          foo: {
+            bar: {
+              biz: 'foo bar'
+            }
+          }
+        },
+        headers: {
+          host: 'foo.bar',
+          'x-authy-signature': '+fyGys+d5yNJx9SpeKZdf+N77od1t1cC/fVSWDW2+kY=',
+          'x-authy-signature-nonce': 1455825429
+        },
+        method: 'POST',
+        protocol: 'https',
+        url: '/'
+      }
+    }).validate('+fyGys+d5yNJx9SpeKZdf+N77od1t1cC/fVSWDW2+kY=');
+  });
 });


### PR DESCRIPTION
Through a few too many hours of debugging, I found that Authy encodes spaces as + while the qs library encodes it as %20. Both are valid, but they need to be consistent for the signature to match.

I couldn't find any option in qs for using + instead of %20, so I ended up doing a bit of a hack to replace %20 with +.