### PR TITLE
Fix tests not passing

### DIFF
--- a/test/client_test.js
+++ b/test/client_test.js
@@ -974,17 +974,6 @@ describe('Client', () => {
       }
     });
 
-    it('should throw an error if `message` is blank', async () => {
-      try {
-        await client.createApprovalRequest({ message: '' });
-
-        should.fail();
-      } catch (e) {
-        e.should.be.instanceOf(ValidationFailedError);
-        e.errors.message[0].show().assert.should.equal('Required');
-      }
-    });
-
     it('should throw an error if `message` has more than 144 characters', async () => {
       try {
         await client.createApprovalRequest({ message: 'f'.repeat(145) });


### PR DESCRIPTION
Due to `validator.js` is in the package.json with at least 2.0.0 (^2.0.0), with the version **2.0.0 tests pass**, but in the latest version (`2.0.3`) it does not pass.

In `validator.js` the `Required Assert` was simplified (see https://github.com/guillaumepotier/validator.js/commit/d8a10a391953102552902c6c511aaa347a88eb18) which makes the failing test deprecated.

Fixes https://github.com/seegno/authy-client/issues/14.