### PR TITLE
Update _app_serial_id constraint to accept integer values

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -208,7 +208,7 @@ export default class Client {
         assert(response, {
           approval_request: {
             _app_name: [is.required(), is.string()],
-            _app_serial_id: [is.required(), is.string()],
+            _app_serial_id: [is.required(), is.integer()],
             _authy_id: [is.required(), is.authyId()],
             _id: [is.required(), is.string()],
             _user_email: [is.required(), is.email()],

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -858,7 +858,7 @@ describe('Client', () => {
       nock(/authy/).get(/\//).reply(200, {
         approval_request: {
           _app_name: 123,
-          _app_serial_id: 123,
+          _app_serial_id: '123',
           _authy_id: 'foo',
           _id: 123,
           _user_email: 'bar',
@@ -882,7 +882,7 @@ describe('Client', () => {
         e.should.be.instanceOf(AssertionFailedError);
 
         e.errors.approval_request._app_name[0].show().assert.should.equal('IsString');
-        e.errors.approval_request._app_serial_id[0].show().assert.should.equal('IsString');
+        e.errors.approval_request._app_serial_id[0].show().assert.should.equal('Integer');
         e.errors.approval_request._authy_id[0].show().assert.should.equal('AuthyId');
         e.errors.approval_request._id[0].show().assert.should.equal('IsString');
         e.errors.approval_request._user_email[0].show().assert.should.equal('Email');

--- a/test/mocks/get-approval-request-mock.js
+++ b/test/mocks/get-approval-request-mock.js
@@ -40,7 +40,7 @@ export function succeed({ request, status = 'approved' } = {}) {
       body: {
         approval_request: {
           _app_name: 'Test',
-          _app_serial_id: '29225',
+          _app_serial_id: 29225,
           _authy_id: '1635',
           _id: '56ad18731170706b7f00e352',
           _user_email: 'foo@bar.com',


### PR DESCRIPTION
The `_app_serial_id` has been updated to accept an integer instead as observed on Authy's API.