### PR TITLE
Actually post data as application/json, not form-data

### DIFF
--- a/src/asserts/signature-assert.js
+++ b/src/asserts/signature-assert.js
@@ -37,7 +37,10 @@ export default function signatureAssert({ key, request } = {}) {
     const url = parse(`${protocol}://${host}${path}`, true);
 
     // Stringify body using sorted keys and encoding spaces as "+" instead of "%20".
-    const encoded = qs.stringify(body, { sort: (a, b) => a.localeCompare(b) }).replace(/%20/g, '+');
+    const encoded = qs.stringify(body, {
+      arrayFormat: 'brackets',
+      sort: (a, b) => a.localeCompare(b)
+    }).replace(/%20/g, '+');
 
     const data = `${nonce}|${method}|${url.protocol}//${url.host}${url.pathname}|${encoded}`;
     const signature = createHmac('sha256', this.key).update(data).digest('base64');

--- a/src/client.js
+++ b/src/client.js
@@ -94,7 +94,7 @@ export default class Client {
       });
 
       return this.onetouch.postAsync({
-        form: {
+        body: {
           api_key: this.key,
           details: details.visible,
           hidden_details: details.hidden,
@@ -133,7 +133,7 @@ export default class Client {
       });
 
       return this.rpc.postAsync({
-        form: _.pickBy({
+        body: _.pickBy({
           user_ip: ip
         }, _.identity),
         uri: esc`users/${authyId}/delete`
@@ -310,7 +310,7 @@ export default class Client {
       });
 
       return this.rpc.getAsync({
-        form: _.pickBy({
+        body: _.pickBy({
           user_ip: ip
         }, _.identity),
         uri: esc`users/${authyId}/status`
@@ -353,7 +353,7 @@ export default class Client {
       });
 
       return this.rpc.postAsync({
-        form: {
+        body: {
           data,
           type,
           user_ip: ip
@@ -473,7 +473,7 @@ export default class Client {
       const parsed = parsePhone({ countryOrCallingCode, phone });
 
       return this.rpc.postAsync({
-        form: {
+        body: {
           user: {
             cellphone: parsed.phone,
             country_code: parsed.countryCallingCode,
@@ -548,7 +548,7 @@ export default class Client {
       const parsed = parsePhone({ countryOrCallingCode, phone });
 
       return this.rpc.postAsync({
-        form: _.pickBy({
+        body: _.pickBy({
           country_code: parsed.countryCallingCode,
           locale,
           phone_number: parsed.phone,

--- a/src/client.js
+++ b/src/client.js
@@ -583,7 +583,7 @@ export default class Client {
       validate(request, {
         body: {
           approval_request: [is.required(), is.callback(value => {
-            return is.string().check(value) === true || is.plainObject().check(value) === true;
+            return is.integer().check(value) === true || is.string().check(value) === true || is.plainObject().check(value) === true;
           })],
           authy_id: [is.required(), is.authyId()],
           callback_action: [is.required(), is.choice(['approval_request_status'])],

--- a/src/client.js
+++ b/src/client.js
@@ -583,7 +583,7 @@ export default class Client {
       validate(request, {
         body: {
           approval_request: [is.required(), is.callback(value => {
-            return is.integer().check(value) === true || is.string().check(value) === true || is.plainObject().check(value) === true;
+            return is.string().check(value) === true || is.plainObject().check(value) === true;
           })],
           authy_id: [is.required(), is.authyId()],
           callback_action: [is.required(), is.choice(['approval_request_status'])],

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -242,7 +242,7 @@ describe('Client', () => {
 
     it('should throw an error if `body.approval_request` is invalid', async () => {
       try {
-        await client.verifyCallback({ body: { approval_request: 123 }, method: 'POST', protocol: 'http', url: '/' });
+        await client.verifyCallback({ body: { approval_request: true }, method: 'POST', protocol: 'http', url: '/' });
 
         should.fail();
       } catch (e) {
@@ -528,7 +528,10 @@ describe('Client', () => {
               device_signing_time: 0,
               encrypted: false,
               flagged: false,
-              hidden_details: {},
+              hidden_details: {
+                integer: 12,
+                string: 'foo'
+              },
               message: '.',
               reason: null,
               requester_details: null,
@@ -545,7 +548,7 @@ describe('Client', () => {
         },
         headers: {
           host: 'foo.bar',
-          'x-authy-signature': 'hqB6las54sMBA83GKs0U1QQi9ocJ2tH20SXHZNzfqqQ=',
+          'x-authy-signature': '1oyl899IjkMH2Y1ldpdbhRSwVwlEHb7yzlITSeqLNsQ=',
           'x-authy-signature-nonce': '1455825429'
         },
         method: 'POST',

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -242,7 +242,7 @@ describe('Client', () => {
 
     it('should throw an error if `body.approval_request` is invalid', async () => {
       try {
-        await client.verifyCallback({ body: { approval_request: true }, method: 'POST', protocol: 'http', url: '/' });
+        await client.verifyCallback({ body: { approval_request: 123 }, method: 'POST', protocol: 'http', url: '/' });
 
         should.fail();
       } catch (e) {
@@ -528,10 +528,7 @@ describe('Client', () => {
               device_signing_time: 0,
               encrypted: false,
               flagged: false,
-              hidden_details: {
-                integer: 12,
-                string: 'foo'
-              },
+              hidden_details: {},
               message: '.',
               reason: null,
               requester_details: null,
@@ -548,7 +545,7 @@ describe('Client', () => {
         },
         headers: {
           host: 'foo.bar',
-          'x-authy-signature': '1oyl899IjkMH2Y1ldpdbhRSwVwlEHb7yzlITSeqLNsQ=',
+          'x-authy-signature': 'hqB6las54sMBA83GKs0U1QQi9ocJ2tH20SXHZNzfqqQ=',
           'x-authy-signature-nonce': '1455825429'
         },
         method: 'POST',

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -203,7 +203,7 @@ describe('Client', () => {
       mocks.startPhoneVerification.succeed({
         request: {
           body: {
-            country_code: '1',
+            country_code: 1,
             locale: 'es',
             phone_number: '7754615609',
             via: 'sms'
@@ -1086,17 +1086,24 @@ describe('Client', () => {
       mocks.createApprovalRequest.succeed({
         request: {
           body: {
-            api_key: '{key}',
-            'details[Account Number]': '981266321',
-            'details[location]': 'California, USA',
-            'details[username]': 'Bill Smith',
-            'hidden_details[ip_address]': '10.10.3.203',
-            'logos[0][res]': 'default',
-            'logos[0][url]': 'https://example.com/logos/default.png',
-            'logos[1][res]': 'low',
-            'logos[1][url]': 'https://example.com/logos/low.png',
+            api_key: '1DS9YIwGquvvIdx8GdcdqZGLAewZZyhd',
+            details: {
+              'Account Number': '981266321',
+              location: 'California, USA',
+              username: 'Bill Smith'
+            },
+            hidden_details: {
+              ip_address: '10.10.3.203'
+            },
+            logos: [{
+              res: 'default',
+              url: 'https://example.com/logos/default.png'
+            }, {
+              res: 'low',
+              url: 'https://example.com/logos/low.png'
+            }],
             message: 'Login requested for a CapTrade Bank account.',
-            seconds_to_expire: '120'
+            seconds_to_expire: 120
           }
         }
       });
@@ -1256,9 +1263,11 @@ describe('Client', () => {
       mocks.registerUser.succeed({
         request: {
           body: {
-            'user[cellphone]': '911234567',
-            'user[country_code]': '351',
-            'user[email]': 'foo@bar.com'
+            user: {
+              cellphone: '911234567',
+              country_code: 351,
+              email: 'foo@bar.com'
+            }
           }
         }
       });
@@ -2101,7 +2110,17 @@ describe('Client', () => {
     });
 
     it('should register the activity', async () => {
-      mocks.registerActivity.succeed({ request: { body: { 'data[reason]': 'foo', type: 'banned', user_ip: '86.112.56.34' } } });
+      mocks.registerActivity.succeed({
+        request: {
+          body: {
+            data: {
+              reason: 'foo'
+            },
+            type: 'banned',
+            user_ip: '86.112.56.34'
+          }
+        }
+      });
 
       await client.registerActivity({ authyId: 1635, data: { reason: 'foo' }, type: 'banned' }, { ip: '86.112.56.34' });
     });

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -1086,7 +1086,7 @@ describe('Client', () => {
       mocks.createApprovalRequest.succeed({
         request: {
           body: {
-            api_key: '1DS9YIwGquvvIdx8GdcdqZGLAewZZyhd',
+            api_key: client.key,
             details: {
               'Account Number': '981266321',
               location: 'California, USA',


### PR DESCRIPTION
After trying to get logos to work in approval request for way too long, I found that the data submitted to Authy was not actually being sent as JSON. It was a bit confusing since the path was /json and the headers was set, but in reality the `form` property was used instead of `body` on the `request` methods.

Logos didn't work because Authy expects them in the form `logos[][res]...`, while the json was being encoded to form-data as `logos[0][res]...`. 

Rather than try to fix that, I think the right solution is to actually send as json. This PR changes this and adjusts the tests.