### PR TITLE
Replace api_key querystring or body parameter by more secure header

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -55,7 +55,8 @@ export default class Client {
     // Request default options.
     this.defaults = {
       headers: {
-        'User-Agent': `${manifest.name}/${manifest.version} (${manifest.homepage})`
+        'User-Agent': `${manifest.name}/${manifest.version} (${manifest.homepage})`,
+        'X-Authy-API-Key': this.key
       },
       json: true,
       strictSSL: true,
@@ -63,8 +64,7 @@ export default class Client {
     };
 
     this.rpc = Promise.promisifyAll(request.defaults(_.defaultsDeep({
-      baseUrl: `${this.host}/protected/json/`,
-      qs: { api_key: this.key }
+      baseUrl: `${this.host}/protected/json/`
     }, this.defaults)), { multiArgs: true });
 
     this.onetouch = Promise.promisifyAll(request.defaults(_.defaultsDeep({
@@ -95,7 +95,6 @@ export default class Client {
 
       return this.onetouch.postAsync({
         body: {
-          api_key: this.key,
           details: details.visible,
           hidden_details: details.hidden,
           logos,
@@ -196,12 +195,7 @@ export default class Client {
         id: [is.required(), is.string()]
       });
 
-      return this.onetouch.getAsync({
-        qs: {
-          api_key: this.key
-        },
-        uri: esc`approval_requests/${id}`
-      })
+      return this.onetouch.getAsync({ uri: esc`approval_requests/${id}` })
       .bind(this)
       .then(parseResponse)
       .tap(response => {

--- a/src/logging/request-obfuscator.js
+++ b/src/logging/request-obfuscator.js
@@ -3,24 +3,22 @@
  * Module dependencies.
  */
 
-import { isString } from 'lodash';
+import { has } from 'lodash';
 
 /**
  * Instances.
  */
 
-const replacement = /(api_key=)([^&])*/;
+const key = 'X-Authy-API-Key';
 
 /**
  * Export `RequestObfuscator`.
  */
 
 export function obfuscate(request) {
-  // Obfuscate the API key on `uri`.
-  request.uri = request.uri.replace(replacement, '$1*****');
-
-  // Obfuscate the API key on `body`.
-  if (isString(request.body)) {
-    request.body = request.body.replace(replacement, '$1*****');
+  if (!has(request, `headers.${key}`)) {
+    return request;
   }
+
+  request.headers[key] = '*****';
 }

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -696,7 +696,6 @@ describe('Client', () => {
       mocks.verifyPhone.succeed({
         request: {
           query: {
-            api_key: '{key}',
             country_code: '1',
             phone_number: '7754615609',
             verification_code: '1234'
@@ -1086,7 +1085,6 @@ describe('Client', () => {
       mocks.createApprovalRequest.succeed({
         request: {
           body: {
-            api_key: client.key,
             details: {
               'Account Number': '981266321',
               location: 'California, USA',

--- a/test/logging/request-obfuscator_test.js
+++ b/test/logging/request-obfuscator_test.js
@@ -12,29 +12,23 @@ import { obfuscate } from '../../src/logging/request-obfuscator';
 
 describe('RequestObfuscator', () => {
   describe('obfuscate()', () => {
-    it('should strip credentials from query string', () => {
-      const request = {
-        id: '354f8341-eb27-4c91-a8f7-a30e303a0976',
-        method: 'GET',
-        uri: 'foo=bar&api_key=foobar'
-      };
+    it('should ignore a request that does not include headers', () => {
+      // A request object with type `response` won't have headers.
+      const request = {};
 
-      obfuscate(request);
-
-      request.should.eql(defaults({ uri: 'foo=bar&api_key=*****' }, request));
+      obfuscate(request).should.equal(request);
     });
 
-    it('should strip credentials from request `body`', () => {
+    it('should strip credentials from header', () => {
       const request = {
-        body: 'foo=bar&api_key=foobar',
-        id: '354f8341-eb27-4c91-a8f7-a30e303a0976',
-        method: 'GET',
-        uri: 'foo=bar&api_key=foobar'
+        headers: {
+          'X-Authy-API-Key': 'foobar'
+        }
       };
 
       obfuscate(request);
 
-      request.should.eql(defaults({ body: 'foo=bar&api_key=*****' }, request));
+      request.should.eql(defaults({ headers: { 'X-Authy-API-Key': '*****' } }, request));
     });
   });
 });

--- a/test/mocks/create-approval-request-mock.js
+++ b/test/mocks/create-approval-request-mock.js
@@ -13,7 +13,6 @@ import uuid from '../utils/uuid';
 function mock({ request = {}, response = {} }) {
   return nock(/\.authy\.com/)
     .filteringPath(path => path.replace(/\d+/, '{authyId}'))
-    .filteringRequestBody(body => body.replace(/key=.*?(&|$)/, 'key={key}$1'))
     .post('/onetouch/json/users/{authyId}/approval_requests', request.body)
     .reply(response.code, response.body);
 }

--- a/test/mocks/delete-user-mock.js
+++ b/test/mocks/delete-user-mock.js
@@ -11,8 +11,8 @@ import nock from 'nock';
 
 function mock({ request = {}, response = {} }) {
   return nock(/\.authy\.com/)
-    .filteringPath(path => path.replace(/\=[^&].+/, '={key}').replace(/\/[0-9].*\//, '/{authyId}/'))
-    .post('/protected/json/users/{authyId}/delete?api_key={key}', request.body)
+    .filteringPath(path => path.replace(/\/[0-9].*\//, '/{authyId}/'))
+    .post('/protected/json/users/{authyId}/delete', request.body)
     .reply(response.code, response.body);
 }
 

--- a/test/mocks/get-application-details-mock.js
+++ b/test/mocks/get-application-details-mock.js
@@ -3,7 +3,6 @@
  * Module dependencies.
  */
 
-import { defaults } from 'lodash';
 import nock from 'nock';
 
 /**
@@ -12,9 +11,8 @@ import nock from 'nock';
 
 function mock({ request = {}, response = {} }) {
   return nock(/\.authy\.com/)
-    .filteringPath(path => path.replace(/key=.*?(&|$)/, 'key={key}$1'))
     .get('/protected/json/app/details')
-    .query(request.query ? defaults({ api_key: '{key}' }, request.query) : true)
+    .query(request.query ? request.query : true)
     .reply(response.code, response.body);
 }
 

--- a/test/mocks/get-application-statistics-mock.js
+++ b/test/mocks/get-application-statistics-mock.js
@@ -4,7 +4,7 @@
  */
 
 import nock from 'nock';
-import { defaults, random, times } from 'lodash';
+import { random, times } from 'lodash';
 
 /**
  * List of month names.
@@ -18,9 +18,8 @@ const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 
 
 function mock({ request = {}, response = {} }) {
   return nock(/\.authy\.com/)
-    .filteringPath(path => path.replace(/key=.*?(&|$)/, 'key={key}$1'))
     .get('/protected/json/app/stats')
-    .query(request.query ? defaults({ api_key: '{key}' }, request.query) : true)
+    .query(request.query ? request.query : true)
     .reply(response.code, response.body);
 }
 

--- a/test/mocks/get-approval-request-mock.js
+++ b/test/mocks/get-approval-request-mock.js
@@ -3,7 +3,6 @@
  * Module dependencies.
  */
 
-import { defaults } from 'lodash';
 import nock from 'nock';
 import uuid from '../utils/uuid';
 
@@ -13,9 +12,9 @@ import uuid from '../utils/uuid';
 
 function mock({ request = {}, response = {} }) {
   return nock(/\.authy\.com/)
-    .filteringPath(path => path.replace(/key=.*?(&|$)/, 'key={key}$1').replace(/[\w]{8}(-[\w]{4}){3}-[\w]{12}/, '{id}'))
+    .filteringPath(path => path.replace(/[\w]{8}(-[\w]{4}){3}-[\w]{12}/, '{id}'))
     .get('/onetouch/json/approval_requests/{id}')
-    .query(request.query ? defaults({ api_key: '{key}' }, request.query) : true)
+    .query(request.query ? request.query : true)
     .reply(response.code, response.body);
 }
 

--- a/test/mocks/get-phone-information-mock.js
+++ b/test/mocks/get-phone-information-mock.js
@@ -3,7 +3,6 @@
  * Module dependencies.
  */
 
-import { defaults } from 'lodash';
 import nock from 'nock';
 
 /**
@@ -12,9 +11,8 @@ import nock from 'nock';
 
 function mock({ request = {}, response = {} }) {
   return nock(/\.authy\.com/)
-    .filteringPath(path => path.replace(/key=.*?(&|$)/, 'key={key}$1'))
     .get('/protected/json/phones/info')
-    .query(request.query ? defaults({ api_key: '{key}' }, request.query) : true)
+    .query(request.query ? request.query : true)
     .reply(response.code, response.body);
 }
 

--- a/test/mocks/get-user-status-mock.js
+++ b/test/mocks/get-user-status-mock.js
@@ -3,7 +3,6 @@
  * Module dependencies.
  */
 
-import { defaults } from 'lodash';
 import nock from 'nock';
 
 /**
@@ -12,9 +11,9 @@ import nock from 'nock';
 
 function mock({ request = {}, response = {} }) {
   return nock(/\.authy\.com/)
-    .filteringPath(path => path.replace(/\=[^&].+/, '={key}').replace(/\/[0-9].*\//, '/{authyId}/'))
+    .filteringPath(path => path.replace(/\/[0-9].*\//, '/{authyId}/'))
     .get('/protected/json/users/{authyId}/status', request.body)
-    .query(request.query ? defaults({ api_key: '{key}' }, request.query) : true)
+    .query(request.query ? request.query : true)
     .reply(response.code, response.body);
 }
 

--- a/test/mocks/register-activity-mock.js
+++ b/test/mocks/register-activity-mock.js
@@ -3,7 +3,6 @@
  * Module dependencies.
  */
 
-import { defaults } from 'lodash';
 import nock from 'nock';
 
 /**
@@ -12,9 +11,9 @@ import nock from 'nock';
 
 function mock({ request = {}, response = {} }) {
   return nock(/\.authy\.com/)
-    .filteringPath(path => path.replace(/\=[^&].+/, '={key}').replace(/\/[0-9].*\//, '/{authyId}/'))
+    .filteringPath(path => path.replace(/\/[0-9].*\//, '/{authyId}/'))
     .post('/protected/json/users/{authyId}/register_activity', request.body)
-    .query(request.query ? defaults({ api_key: '{key}' }, request.query) : true)
+    .query(request.query ? request.query : true)
     .reply(response.code, response.body);
 }
 

--- a/test/mocks/register-user-mock.js
+++ b/test/mocks/register-user-mock.js
@@ -3,7 +3,6 @@
  * Module dependencies.
  */
 
-import { defaults } from 'lodash';
 import nock from 'nock';
 
 /**
@@ -12,9 +11,8 @@ import nock from 'nock';
 
 function mock({ request = {}, response = {} }) {
   return nock(/\.authy\.com/)
-    .filteringPath(path => path.replace(/\=[^&].+/, '={key}'))
     .post('/protected/json/users/new', request.body)
-    .query(request.query ? defaults({ api_key: '{key}' }, request.query) : true)
+    .query(request.query ? request.query : true)
     .reply(response.code, response.body);
 }
 

--- a/test/mocks/request-call-mock.js
+++ b/test/mocks/request-call-mock.js
@@ -3,7 +3,6 @@
  * Module dependencies.
  */
 
-import { defaults } from 'lodash';
 import nock from 'nock';
 
 /**
@@ -12,9 +11,9 @@ import nock from 'nock';
 
 function mock({ request = {}, response = {} }) {
   return nock(/\.authy\.com/)
-    .filteringPath(path => path.replace(/key=.*?(&|$)/, 'key={key}$1').replace(/\/[0-9].*\?/, '/{authyId}?'))
+    .filteringPath(path => path.replace(/\/[0-9].*/, '/{authyId}'))
     .get('/protected/json/call/{authyId}')
-    .query(request.query ? defaults({ api_key: '{key}' }, request.query) : true)
+    .query(request.query ? request.query : true)
     .reply(response.code, response.body);
 }
 

--- a/test/mocks/request-sms-mock.js
+++ b/test/mocks/request-sms-mock.js
@@ -3,7 +3,6 @@
  * Module dependencies.
  */
 
-import { defaults } from 'lodash';
 import nock from 'nock';
 
 /**
@@ -12,9 +11,9 @@ import nock from 'nock';
 
 function mock({ request = {}, response = {} }) {
   return nock(/\.authy\.com/)
-    .filteringPath(path => path.replace(/key=.*?(&|$)/, 'key={key}$1').replace(/\/[0-9].*\?/, '/{authyId}?'))
+    .filteringPath(path => path.replace(/\/[0-9].*/, '/{authyId}'))
     .get('/protected/json/sms/{authyId}')
-    .query(request.query ? defaults({ api_key: '{key}' }, request.query) : true)
+    .query(request.query ? request.query : true)
     .reply(response.code, response.body);
 }
 

--- a/test/mocks/start-phone-verification-mock.js
+++ b/test/mocks/start-phone-verification-mock.js
@@ -3,7 +3,6 @@
  * Module dependencies.
  */
 
-import { defaults } from 'lodash';
 import nock from 'nock';
 
 /**
@@ -12,9 +11,8 @@ import nock from 'nock';
 
 function mock({ request = {}, response = {} }) {
   return nock(/\.authy\.com/)
-    .filteringPath(path => path.replace(/\=[^&].+/, '={key}'))
     .post('/protected/json/phones/verification/start', request.body)
-    .query(request.query ? defaults({ api_key: '{key}' }, request.query) : true)
+    .query(request.query ? request.query : true)
     .reply(response.code, response.body);
 }
 

--- a/test/mocks/verify-phone-mock.js
+++ b/test/mocks/verify-phone-mock.js
@@ -3,7 +3,6 @@
  * Module dependencies.
  */
 
-import { defaults } from 'lodash';
 import nock from 'nock';
 
 /**
@@ -13,8 +12,6 @@ import nock from 'nock';
 function mock({ request = {}, response = {} }) {
   return nock(/\.authy\.com/)
     .filteringPath(path => {
-      path = path.replace(/key=.*?(&|$)/, 'key={key}$1');
-
       if (!(request.query && request.query.verification_code)) {
         return path.replace(/verification_code=.*?(&|$)/, 'verification_code={token}$1');
       }
@@ -22,7 +19,7 @@ function mock({ request = {}, response = {} }) {
       return path;
     })
     .get('/protected/json/phones/verification/check')
-    .query(request.query ? defaults({ api_key: '{key}' }, request.query) : true)
+    .query(request.query ? request.query : true)
     .reply(response.code, response.body);
 }
 

--- a/test/mocks/verify-token-mock.js
+++ b/test/mocks/verify-token-mock.js
@@ -3,7 +3,6 @@
  * Module dependencies.
  */
 
-import { defaults } from 'lodash';
 import nock from 'nock';
 
 /**
@@ -12,9 +11,9 @@ import nock from 'nock';
 
 function mock({ request = {}, response = {} }) {
   return nock(/\.authy\.com/)
-    .filteringPath(path => path.replace(/key=.*?(&|$)/, 'key={key}$1').replace(/verify\/.*?\//, 'verify/{token}/').replace(/\/[0-9].*\?/, '/{authyId}?'))
+    .filteringPath(path => path.replace(/verify\/.*?\//, 'verify/{token}/').replace(/\/[0-9].*/, '/{authyId}'))
     .get('/protected/json/verify/{token}/{authyId}')
-    .query(request.query ? defaults({ api_key: '{key}' }, request.query) : true)
+    .query(request.query ? request.query : true)
     .reply(response.code, response.body);
 }
 


### PR DESCRIPTION
Looks like Authy finally migrated away from the querystring/body parameter `api_key` and now uses an header for authentication.