### PR TITLE
Remove required assert from is_ported on start phone verification

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -556,7 +556,7 @@ export default class Client {
         assert(response, {
           carrier: [is.required(), is.string()],
           is_cellphone: [is.required(), is.boolean()],
-          is_ported: [is.required(), is.boolean()],
+          is_ported: is.boolean(),
           message: [is.required(), is.string()]
         });
       })

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -177,7 +177,6 @@ describe('Client', () => {
 
         e.errors.message.show().assert.should.equal('HaveProperty');
         e.errors.is_cellphone.show().assert.should.equal('HaveProperty');
-        e.errors.is_ported.show().assert.should.equal('HaveProperty');
         e.errors.message.show().assert.should.equal('HaveProperty');
       }
     });


### PR DESCRIPTION
Looks like is_ported is not guaranteed to be returned from the API as mentioned in https://github.com/seegno/authy-client/issues/19.

Closes #19.