### PR TITLE
Remove required assert from activity data and ip

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -341,9 +341,9 @@ export default class Client {
 
       validate({ authyId, data, ip, type }, {
         authyId: [is.required(), is.authyId()],
-        data: [is.required(), is.plainObject()],
-        ip: [is.required(), is.Ip()],
-        type: [is.required(), is.Activity()]
+        data: is.plainObject(),
+        ip: is.ip(),
+        type: [is.required(), is.activity()]
       });
 
       return this.rpc.postAsync({

--- a/test/client_test.js
+++ b/test/client_test.js
@@ -2034,7 +2034,7 @@ describe('Client', () => {
   });
 
   describe('registerActivity()', () => {
-    ['authyId', 'type', 'ip'].forEach(parameter => {
+    ['authyId', 'type'].forEach(parameter => {
       it(`should throw an error if \`${parameter}\` is missing`, async () => {
         try {
           await client.registerActivity();
@@ -2055,6 +2055,17 @@ describe('Client', () => {
       } catch (e) {
         e.should.be.instanceOf(ValidationFailedError);
         e.errors.authyId[0].show().assert.should.equal('AuthyId');
+      }
+    });
+
+    it('should throw an error if `data` is invalid', async () => {
+      try {
+        await client.registerActivity({ data: '' });
+
+        should.fail();
+      } catch (e) {
+        e.should.be.instanceOf(ValidationFailedError);
+        e.errors.data[0].show().assert.should.equal('PlainObject');
       }
     });
 


### PR DESCRIPTION
None of the two parameters are really required - just the authy id and the type.